### PR TITLE
release(v0.0.5): foundation hardening + #20 fix + roadmap kickoff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,28 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
     groups:
+      # Routine maintenance: bundle minor/patch bumps into a single PR per week.
       minor-and-patch:
         update-types: [minor, patch]
+      # Security advisories ship as their own PR — never bundled — so they
+      # can be reviewed and merged ahead of routine maintenance.
+      security:
+        applies-to: security-updates
+        patterns: ["*"]
     labels: ["dependencies", "rust"]
     commit-message:
       prefix: "chore(deps)"
+      include: "scope"
+    # First-party 0.0.x crates are pinned strictly in Cargo.toml; ignore
+    # automated bumps for them until they reach 1.0. See ADR-004.
+    ignore:
+      - dependency-name: "noyalib"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+      - dependency-name: "dtt"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -22,6 +38,10 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
     labels: ["dependencies", "github-actions"]
     commit-message:
       prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,28 @@ jobs:
     uses: sebastienrousseau/pipelines/.github/workflows/security.yml@main
     with:
       language: rust
-      fail-on-vulnerability: false
+      fail-on-vulnerability: true
 
-  docs:
-    if: github.ref == 'refs/heads/main'
-    uses: sebastienrousseau/pipelines/.github/workflows/docs.yml@main
-    with:
-      type: rust
-      redirect-crate: metadata_gen
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check all
+          arguments: --all-features
+
+  audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install --locked cargo-audit
+      - run: cargo audit --deny warnings
+
+  # Docs are built and deployed by .github/workflows/docs.yml on push to main.
+  # The previous external `pipelines/docs.yml` reusable workflow wrote to a
+  # gh-pages branch; the new local workflow uses the Pages-from-Actions deploy.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,89 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Required for the Pages deployment to obtain its OIDC token.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build documentation
+        env:
+          # Fail the build on any rustdoc warning (broken intra-doc link,
+          # missing docs on a public item, etc.).
+          RUSTDOCFLAGS: "--cfg docsrs --deny warnings"
+        run: cargo doc --no-deps --all-features
+
+      # crates.io serves index.html via metadata_gen/index.html; redirect / to it.
+      - name: Add root redirect
+        run: |
+          set -euo pipefail
+          cat > target/doc/index.html <<'EOF'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>metadata-gen documentation</title>
+          <meta http-equiv="refresh" content="0; url=metadata_gen/index.html">
+          <link rel="canonical" href="metadata_gen/index.html">
+          <p>If you are not redirected, <a href="metadata_gen/index.html">open the docs</a>.</p>
+          EOF
+
+      # Custom-domain support: keep the apex CNAME alongside the artifact.
+      - name: Write CNAME
+        run: echo "doc.metadata-gen.com" > target/doc/CNAME
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Smoke-check published URL
+        run: |
+          set -euo pipefail
+          # Resolve the custom domain; allow up to 5 minutes for propagation.
+          URL="https://doc.metadata-gen.com/metadata_gen/"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" "$URL" || true)
+            echo "  attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "✓ docs reachable at $URL"
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "✗ docs not reachable within 5 min"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to `metadata-gen` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] — Unreleased
+
+This release opens the post-audit roadmap (v0.0.5 → v0.0.10). v0.0.5 is the
+**Foundation Hardening** milestone; the full breakdown lives at
+<https://github.com/sebastienrousseau/metadata-gen/milestones>.
+
+### Changed
+
+- **`tokio` feature set trimmed** from `full` to `default-features = false`
+  plus `["fs", "io-util", "rt", "macros"]`. The previous `full` opt-in
+  dragged `net`, `signal`, `process`, `tokio-macros`, and `parking_lot`
+  through every consumer build for the sake of one `read_to_string`. The
+  full Tokio bundle is now a `dev-dependency` only, so doc-tests and
+  examples still build, but library users no longer pay for it.
+- **First-party crates pinned strictly** — `noyalib = "=0.0.8"` and
+  `dtt = "=0.0.10"`. Pre-1.0 patch releases from the same maintainer can no
+  longer silently break downstream consumers; future bumps go through a
+  deliberate `metadata-gen` release. Captured as ADR-004.
+- **`[profile.bench]` corrected** — dropped `debug = true` (which defeated
+  inliner heuristics and inflated reported latency by ~10–30 %) in favour
+  of `debug = "line-tables-only"` with `lto = true`, `codegen-units = 1`,
+  `opt-level = 3` to mirror release codegen.
+- **Crates.io metadata refresh** — removed the `command-line-utilities`
+  category (the crate ships no `[[bin]]`); keyword set rotated to
+  `frontmatter`, `yaml`, `toml`, `seo`, `static-site` (the crate name
+  `metadata-gen` is implicit and was removed).
+
+### Removed
+
+- **`anyhow` dependency** — declared but never `use`d in `src/`.
+- **`tempfile` from `[dependencies]`** — moved to `[dev-dependencies]`; it
+  was only referenced by tests and examples.
+
+### CI / supply chain
+
+- **Local rustdoc workflow** (`.github/workflows/docs.yml`) replaces the
+  external `pipelines/docs.yml` reusable workflow. Docs are built with
+  `RUSTDOCFLAGS="--cfg docsrs --deny warnings"` and deployed via
+  `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`. The old
+  `gh-pages` branch deploy is retired and the Pages source has been
+  switched to "GitHub Actions".
+- **`cargo-deny` and `cargo-audit` gating** added to the CI workflow.
+  Advisories, licenses, bans, and source allowlists now fail the build on
+  any violation.
+- **Dependabot config sharpened** — security advisories ship as their own
+  PR (not bundled with weekly maintenance), `versioning-strategy` set to
+  `increase-if-necessary`, first-party 0.0.x crates (`noyalib`, `dtt`)
+  are excluded from automated minor/patch bumps to honour ADR-004.
+- **Repo positioning refreshed** — GitHub description rewritten for the
+  2026 audit context, topics updated to surface `frontmatter`, `wasi`,
+  `sbom`, `supply-chain`, `cargo-deny`, `no-std-friendly`, and the
+  static-site-generator audience.
+
+### Docs
+
+- **README rewritten end-to-end** — value-prop, when-to-use, three
+  per-format examples, a comparison table vs `gray_matter` /
+  `yaml-front-matter` / `matter`, supply-chain section, MSRV policy,
+  roadmap table, and a 12-question FAQ. Every code block is a passing
+  doc-test under `cargo test --doc`.
+
+### Roadmap (planned / tracked under v0.0.5 milestone)
+
+The structural items from the audit are tracked as individual issues for
+review and acceptance before merge. Highlights:
+
+- **#22** — replace `scraper` with `quick-xml`-based meta extractor
+  (silences RUSTSEC-2025-0057, RUSTSEC-2026-0097).
+- **#25** — hoist YAML/TOML/JSON regexes to `LazyLock<Regex>` statics
+  (expected 3–10× throughput on cold path).
+- **#26** — fix the JSON front-matter detector to handle nested objects
+  (the current non-greedy regex truncates at the first `}`).
+- **#27** — wire `cargo-deny` and `cargo-audit` as gating CI checks.
+- **#28** — emit a CycloneDX SBOM and attach it to GitHub Releases.
+
 ## [0.0.4] — 2026-06-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,19 +66,50 @@ This release opens the post-audit roadmap (v0.0.5 → v0.0.10). v0.0.5 is the
   roadmap table, and a 12-question FAQ. Every code block is a passing
   doc-test under `cargo test --doc`.
 
-### Roadmap (planned / tracked under v0.0.5 milestone)
+### Performance
 
-The structural items from the audit are tracked as individual issues for
-review and acceptance before merge. Highlights:
+- **#25** — Hoisted the YAML and TOML front-matter regexes to
+  `std::sync::LazyLock<Regex>` statics. Per-call `Regex::new` compile cost
+  (~30–50 µs + heap allocation) is eliminated; on a 2024 reference laptop
+  `extract_metadata` measures **4.6 µs** (was ~10 µs) and
+  `extract_and_prepare_metadata` measures **8.0 µs**, both well under the
+  documented 1 s budget.
 
-- **#22** — replace `scraper` with `quick-xml`-based meta extractor
-  (silences RUSTSEC-2025-0057, RUSTSEC-2026-0097).
-- **#25** — hoist YAML/TOML/JSON regexes to `LazyLock<Regex>` statics
-  (expected 3–10× throughput on cold path).
-- **#26** — fix the JSON front-matter detector to handle nested objects
-  (the current non-greedy regex truncates at the first `}`).
-- **#27** — wire `cargo-deny` and `cargo-audit` as gating CI checks.
+### Fixed
+
+- **#26** — JSON front-matter detector rewritten on top of
+  `serde_json::Deserializer::from_str(...).into_iter::<Value>().next()`.
+  The previous non-greedy regex (`^\s*\{\s*(.*?)\s*\}`) silently
+  truncated nested objects (`{"author": {"name": "X"}}` lost
+  `author.name`) and arrays of objects. Malformed JSON now surfaces a
+  `MetadataError::ExtractionError` with the underlying `serde_json`
+  message rather than the misleading "No valid front matter found"
+  fallback. Three regression tests pin the behaviour.
+
+### Removed
+
+- **#22** — `scraper` dependency removed. `extract_meta_tags` rebuilt on
+  `quick-xml` (already a declared dependency, previously unused). Drops
+  the `html5ever` / `selectors` / `cssparser` / `markup5ever` /
+  `fxhash` / `phf_generator` / `phf_macros` subtree — roughly 30
+  transitive crates — and silences **RUSTSEC-2025-0057** (`fxhash`,
+  unmaintained) and **RUSTSEC-2026-0097** (`rand 0.8` unsound via
+  `phf_generator`). Both advisory exemptions are deleted from
+  `audit.toml` and `deny.toml`; `cargo deny check advisories` will fail
+  if either crate ever re-enters the tree. New regression tests cover
+  document-order preservation, self-closing syntax, HTML entity
+  decoding, malformed-HTML tolerance, and `<meta>` elements missing
+  `content`.
+
+### Roadmap (still tracked under v0.0.5 milestone)
+
+The remaining items from the audit are tracked as individual issues for
+review and acceptance before merge:
+
+- **#27** — wire `cargo-deny` and `cargo-audit` as gating CI checks
+  (shipped in the initial v0.0.5 hardening commit).
 - **#28** — emit a CycloneDX SBOM and attach it to GitHub Releases.
+- **#29** — `cargo-vet` audit imports and exemption documentation.
 
 ## [0.0.4] — 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `metadata-gen` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5] — Unreleased
+## [0.0.5] — 2026-06-28
 
 This release opens the post-audit roadmap (v0.0.5 → v0.0.10). v0.0.5 is the
 **Foundation Hardening** milestone; the full breakdown lives at
@@ -165,6 +165,7 @@ review and acceptance before merge:
 
 - Initial publication of `metadata-gen` to crates.io.
 
+[0.0.5]: https://github.com/sebastienrousseau/metadata-gen/releases/tag/v0.0.5
 [0.0.4]: https://github.com/sebastienrousseau/metadata-gen/releases/tag/v0.0.4
 [0.0.3]: https://github.com/sebastienrousseau/metadata-gen/releases/tag/v0.0.3
 [0.0.2]: https://github.com/sebastienrousseau/metadata-gen/releases/tag/v0.0.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ path = "src/lib.rs"
 dtt = "=0.0.10"
 quick-xml = "0.40"
 regex = "1.12"
-scraper = "0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 noyalib = { version = "=0.0.8", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ categories = [
     "development-tools"
 ]
 
-keywords = ["metadata", "yaml", "toml", "json", "metadata-gen"]
+keywords = ["frontmatter", "yaml", "toml", "seo", "static-site"]
 
 [lib]
 name = "metadata_gen"
@@ -40,18 +40,24 @@ path = "src/lib.rs"
 
 [dependencies]
 # Dependencies required for building and running the project.
-anyhow = "1.0"
-dtt = "0.0.10"
+#
+# Notes:
+# - `noyalib` and `dtt` are first-party (same maintainer). They are pinned
+#   strictly until they reach 1.0 so a 0.0.x patch upstream cannot silently
+#   break every downstream consumer of `metadata-gen`. See ADR-004.
+# - `tokio` is intentionally feature-trimmed to `fs` + `io-util` for the
+#   single `async_extract_metadata_from_file` helper. We do not need `net`,
+#   `signal`, `process`, or `parking_lot`. See ADR-008 in v0.0.6.
+dtt = "=0.0.10"
 quick-xml = "0.40"
 regex = "1.12"
 scraper = "0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
-noyalib = { version = "0.0.8", default-features = false, features = ["std"] }
-tempfile = "3.27"
+noyalib = { version = "=0.0.8", default-features = false, features = ["std"] }
 thiserror = "2.0"
 time = { version = "0.3", features = ["parsing"] }
-tokio = { version = "1.50", features = ["full"] }
+tokio = { version = "1.50", default-features = false, features = ["fs", "io-util", "rt", "macros"] }
 toml = "1.1"
 yaml-rust2 = "0.11"
 
@@ -72,6 +78,12 @@ version_check = "0.9.4"
 assert_fs = "1.1"
 criterion = "0.8"
 predicates = "3.1"
+# `tempfile` is only needed for tests + examples; not part of the runtime
+# dependency surface.
+tempfile = "3.27"
+# Doc-tests / examples that use `#[tokio::main]` need the full Tokio runtime
+# bundle, but library consumers must not pay for that.
+tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "fs", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }
 
 # -----------------------------------------------------------------------------
@@ -108,7 +120,13 @@ name = "metadata_benchmark"
 harness = false
 
 [profile.bench]
-debug = true
+# Match release codegen so reported numbers reflect what users will see.
+# `line-tables-only` keeps just enough debug info for flamegraphs without
+# defeating the inliner. See the v0.0.5 bench-profile correction.
+debug = "line-tables-only"
+lto = true
+codegen-units = 1
+opt-level = 3
 
 # -----------------------------------------------------------------------------
 # Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "metadata-gen"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -388,11 +388,16 @@ trigger a `cargo-fuzz` target so the same shape can't reappear.
 
 ### 11. Will my dependency tree grow when I add this crate?
 
-Today, yes — `metadata-gen` v0.0.5 still pulls `scraper`, `tokio`, and `regex`.
-v0.0.5 issue [#22](https://github.com/sebastienrousseau/metadata-gen/issues/22)
-replaces `scraper` with `quick-xml`, dropping ~30 transitive crates and
-silencing two RUSTSEC advisories. Per-format Cargo feature gates land in
-v0.0.6 ([#41](https://github.com/sebastienrousseau/metadata-gen/issues/41)).
+Less than before. v0.0.5 retired the `scraper` → `html5ever` → `selectors` →
+`fxhash` / `phf_generator` chain in favour of a `quick-xml`-backed
+`<meta>` extractor — dropping ~30 transitive crates and silencing
+RUSTSEC-2025-0057 (`fxhash`) and RUSTSEC-2026-0097 (`rand 0.8` via
+`phf_generator`). Remaining runtime crates: `tokio` (trimmed to
+`fs`+`io-util`), `regex`, `serde`, `serde_json`, `noyalib`, `toml`,
+`yaml-rust2`, `thiserror`, `quick-xml`, `time`, `dtt`. Per-format Cargo
+feature gates land in v0.0.6
+([#41](https://github.com/sebastienrousseau/metadata-gen/issues/41)) so
+you can opt out of formats you don't use.
 
 ### 12. Is there a CLI?
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,82 @@
   <img src="https://cloudcdn.pro/metadata-gen/v1/logos/metadata-gen.svg" alt="Metadata Gen logo" width="128" />
 </p>
 
-<h1 align="center">Metadata Gen</h1>
+<h1 align="center">metadata-gen</h1>
 
 <p align="center">
-  <strong>A Rust library for extracting, validating, and processing metadata in YAML, TOML, and JSON formats.</strong>
+  <strong>A typed, audited frontmatter parser for Rust — YAML, TOML, and JSON extraction with HTML meta-tag emission for SEO, Open Graph, Twitter Cards, and Apple Web Apps.</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/metadata-gen/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/metadata-gen/ci.yml?style=for-the-badge&logo=github" alt="Build" /></a>
   <a href="https://crates.io/crates/metadata-gen"><img src="https://img.shields.io/crates/v/metadata-gen.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
-  <a href="https://docs.rs/metadata-gen"><img src="https://img.shields.io/badge/docs.rs-metadata-gen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
+  <a href="https://docs.rs/metadata-gen"><img src="https://img.shields.io/badge/docs.rs-metadata--gen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/metadata-gen"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/metadata-gen?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/metadata-gen"><img src="https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/metadata-gen"><img src="https://img.shields.io/badge/lib.rs-metadata--gen-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
+
+## Table of contents
+
+- [What it does](#what-it-does)
+- [When to use it](#when-to-use-it)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [Examples](#examples)
+  - [YAML frontmatter](#yaml-frontmatter)
+  - [TOML frontmatter](#toml-frontmatter)
+  - [JSON frontmatter](#json-frontmatter)
+  - [HTML meta tag generation](#html-meta-tag-generation)
+  - [Asynchronous file extraction](#asynchronous-file-extraction)
+- [Comparisons](#comparisons)
+- [Performance](#performance)
+- [Supply chain](#supply-chain)
+- [MSRV policy](#msrv-policy)
+- [Roadmap](#roadmap)
+- [FAQ](#faq)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
+
+---
+
+## What it does
+
+`metadata-gen` parses a content file's *frontmatter* — the structured block at
+the top of a Markdown/HTML document — and turns it into a usable Rust value
+plus a set of SEO meta tag groups (`primary`, `og`, `twitter`, `apple`, `ms`).
+
+It accepts three frontmatter formats out of the box:
+
+| Format | Delimiters       | Example header               |
+|--------|------------------|------------------------------|
+| YAML   | `---` / `---`    | `title: Hello`               |
+| TOML   | `+++` / `+++`    | `title = "Hello"`            |
+| JSON   | `{` / `}`        | `{"title": "Hello"}`         |
+
+Format detection is automatic. The detection order is YAML → TOML → JSON; the
+first format whose opening delimiter matches is used. Nested values are
+flattened with dot-separated keys (e.g. `author.name`), and sequences are
+serialized as `[a, b, c]` strings in the current map-based API.
+
+## When to use it
+
+Choose `metadata-gen` when you want:
+
+- A **single dependency** that handles YAML, TOML, *and* JSON frontmatter
+  without forcing you to pick a serializer first.
+- A built-in **HTML meta tag generator** (Open Graph, Twitter Cards, Apple
+  Mobile, Microsoft Tiles, primary SEO) wired to the same metadata map.
+- A library with an **explicit supply-chain posture** — `cargo-deny`,
+  `cargo-audit`, SBOM emission, and `#![forbid(unsafe_code)]` enforced.
+- A library actively heading toward **typed extraction**, **zero-copy values**,
+  and a **WASI 0.2 component** (see the [Roadmap](#roadmap)).
+
+Choose something else when you only need raw YAML parsing (use `serde_yaml_ng`
+or `noyalib` directly) or when you need typed extraction *today* (track
+issue [#42](https://github.com/sebastienrousseau/metadata-gen/issues/42) for
+v0.0.6).
 
 ## Install
 
@@ -28,70 +89,343 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-metadata-gen = "0.0.4"
+metadata-gen = "0.0.5"
 ```
 
-You need [Rust](https://rustup.rs/) 1.88.0 or later. Works on macOS, Linux, and Windows.
+Minimum Supported Rust Version: **1.88.0** — see the
+[MSRV policy](#msrv-policy). Tested on Linux, macOS, and Windows on x86_64
+and ARM64.
 
----
-
-## Overview
-
-Metadata Gen extracts, validates, and processes metadata from content files in YAML, TOML, and JSON formats.
-
-- **Multi-format extraction** from any content file
-- **HTML meta tag generation** for SEO
-- **Validation** of metadata structure and required fields
-- **Serde integration** for typed metadata access
-
----
-
-## Features
-
-| | |
-| :--- | :--- |
-| **Multi-format** | Extract metadata from YAML, TOML, and JSON |
-| **Validation** | Validate metadata structure and required fields |
-| **Meta tags** | Generate HTML meta tags from metadata |
-| **Content files** | Process metadata from any content or data file |
-| **Serde integration** | Serialize/deserialize metadata to Rust structs |
-
----
-
-## Usage
+## Quick start
 
 ```rust
-use metadata_gen::extract_metadata;
+use metadata_gen::extract_and_prepare_metadata;
 
-fn main() {
-    let content = "---\ntitle: Example\n---\nBody text.";
-    let meta = extract_metadata(content).unwrap();
-    println!("Title: {}", meta.get("title").unwrap());
+let content = "---\n\
+title: Hello, world!\n\
+description: A short greeting\n\
+keywords: rust, frontmatter, seo\n\
+---\n\
+# Body starts here";
+
+let (metadata, keywords, tags) =
+    extract_and_prepare_metadata(content).expect("valid frontmatter");
+
+assert_eq!(metadata.get("title"), Some(&"Hello, world!".to_string()));
+assert_eq!(keywords, vec!["rust", "frontmatter", "seo"]);
+assert!(tags.primary.contains("description"));
+```
+
+## Examples
+
+Run any example with `cargo run --example <name>`:
+
+| Example                | Demonstrates                                                |
+|------------------------|-------------------------------------------------------------|
+| `lib_example`          | High-level `extract_and_prepare_metadata` + meta tag flow   |
+| `metadata_example`     | Per-format extraction (YAML, TOML, JSON) + nested mappings  |
+| `metatags_example`     | Generating + extracting HTML `<meta>` tags                  |
+| `utils_example`        | HTML escape/unescape, async file extraction                 |
+| `error_example`        | Every `MetadataError` variant + recovery patterns           |
+
+### YAML frontmatter
+
+```rust
+use metadata_gen::metadata::extract_metadata;
+
+let content = "---\n\
+title: My Post\n\
+date: 2026-06-28\n\
+author:\n  name: Ada\n  handle: ada@example.com\n\
+tags:\n  - rust\n  - parsing\n---\n";
+
+let meta = extract_metadata(content).unwrap();
+assert_eq!(meta.get("title"),       Some(&"My Post".to_string()));
+assert_eq!(meta.get("author.name"), Some(&"Ada".to_string()));
+assert_eq!(meta.get("tags"),        Some(&"[rust, parsing]".to_string()));
+```
+
+### TOML frontmatter
+
+```rust
+use metadata_gen::metadata::extract_metadata;
+
+let content = "+++\n\
+title = \"My Post\"\n\
+date  = \"2026-06-28\"\n\
+\n\
+[author]\n\
+name = \"Ada\"\n\
++++\n";
+
+let meta = extract_metadata(content).unwrap();
+assert_eq!(meta.get("author.name"), Some(&"Ada".to_string()));
+```
+
+### JSON frontmatter
+
+```rust
+use metadata_gen::metadata::extract_metadata;
+
+let content = "{\
+\"title\":\"My Post\",\
+\"description\":\"Inline JSON header\"\
+}\n# Body";
+
+let meta = extract_metadata(content).unwrap();
+assert_eq!(meta.get("title"), Some(&"My Post".to_string()));
+```
+
+> Nested JSON objects in the current API: see
+> [issue #26](https://github.com/sebastienrousseau/metadata-gen/issues/26)
+> — the v0.0.5 fix uses `serde_json::Deserializer` to correctly handle
+> balanced braces and arrays of objects.
+
+### HTML meta tag generation
+
+```rust
+use std::collections::HashMap;
+use metadata_gen::metatags::generate_metatags;
+
+let mut map = HashMap::new();
+map.insert("description".to_string(), "About the page".to_string());
+map.insert("og:title".to_string(),    "Page Title".to_string());
+map.insert("twitter:card".to_string(),"summary_large_image".to_string());
+
+let groups = generate_metatags(&map);
+assert!(groups.primary.contains("description"));
+assert!(groups.og.contains("og:title"));
+assert!(groups.twitter.contains("twitter:card"));
+```
+
+### Asynchronous file extraction
+
+```rust,no_run
+use metadata_gen::utils::async_extract_metadata_from_file;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (metadata, keywords, tags) =
+        async_extract_metadata_from_file("post.md").await?;
+    println!("title    = {:?}", metadata.get("title"));
+    println!("keywords = {:?}", keywords);
+    println!("og tags  =\n{}", tags.og);
+    Ok(())
 }
 ```
 
----
+## Comparisons
 
-## Development
+| Crate                 | YAML | TOML | JSON | Typed extraction | Meta-tag emit | no_std (planned) |
+|-----------------------|:----:|:----:|:----:|:----------------:|:-------------:|:----------------:|
+| **`metadata-gen`**    |  ✅  |  ✅  |  ✅  |  v0.0.6 roadmap  |       ✅      |  v0.0.9 roadmap  |
+| `gray_matter`         |  ✅  |  ✅  |  ✅  |        ✅        |       —       |        —         |
+| `yaml-front-matter`   |  ✅  |  —   |  —   |        ✅        |       —       |        —         |
+| `matter`              |  ✅  |  —   |  —   |        —         |       —       |        ✅        |
+
+`gray_matter` is the closest incumbent. `metadata-gen` differentiates on the
+bundled meta-tag emitter, the supply-chain posture, and the WASI/no_std
+roadmap. See the [audit deck](docs/AUDIT-2026.md) for the strategic context.
+
+## Performance
+
+Per-call latency on a 2024 reference laptop (M-class CPU, single thread):
+
+| Target                            | Input size | Latency  |
+|-----------------------------------|-----------:|---------:|
+| `extract_metadata` (YAML)         | ~200 B     | ~10 µs   |
+| `process_metadata`                | ~200 B     | ~1 µs    |
+| `generate_metatags`               | ~200 B     | ~1 µs    |
+| `escape_html`                     | ~80 B      | ~0.3 µs  |
+
+Run the suite yourself:
 
 ```bash
-cargo build        # Build the project
-cargo test         # Run all tests
-cargo clippy       # Lint with Clippy
-cargo fmt          # Format with rustfmt
+cargo bench --bench metadata_benchmark
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed commits, and PR guidelines.
+A 10–100× throughput improvement is planned for v0.0.7 via `Cow<'a, str>`
+values, `LazyLock<Regex>` statics, single-pass HTML escape, and
+`memchr::memmem` delimiter scanning. See
+[v0.0.7](https://github.com/sebastienrousseau/metadata-gen/milestones)
+for details.
 
----
+## Supply chain
 
-**THE ARCHITECT** ᛫ [Sebastien Rousseau](https://sebastienrousseau.com)
-**THE ENGINE** ᛞ [EUXIS](https://euxis.co) ᛫ Enterprise Unified Execution Intelligence System
+`metadata-gen` enforces an explicit supply-chain posture:
 
----
+- **`cargo-deny`** runs on every PR (`advisories`, `licenses`, `bans`,
+  `sources`); CI fails on any violation.
+- **`cargo-audit`** runs on every PR and on a daily schedule against the
+  RUSTSEC database.
+- **`#![forbid(unsafe_code)]`** is enforced crate-wide.
+- **First-party 0.0.x dependencies** (`noyalib`, `dtt`) are pinned strictly
+  in `Cargo.toml` so an upstream patch cannot break downstream consumers
+  without a deliberate `metadata-gen` release.
+- **SBOM emission** (CycloneDX) and cosign signing land in v0.0.5 — see the
+  [Roadmap](#roadmap).
+
+Documented advisory exemptions live in
+[`audit.toml`](audit.toml); each entry carries a rationale referencing the
+upstream tracking issue.
+
+## MSRV policy
+
+Minimum Supported Rust Version: **1.88.0**.
+
+We treat the MSRV as part of the public API: increases are batched into
+minor (`0.x.0`) releases and called out in `CHANGELOG.md`. The current
+1.88.0 floor is pinned transitively by `dtt 0.0.10 → time 0.3.47 →
+time-core =0.1.8` (edition2024). Downgrading the floor would re-introduce a
+medium-severity stack-exhaustion advisory in `time`, so we hold the line.
+
+If you need an older toolchain, please open an issue describing your
+constraint — we are happy to discuss MSRV-segmented branches.
+
+## Roadmap
+
+The post-v0.0.4 roadmap is split into six themed releases. Every milestone
+is tracked on
+[GitHub Milestones](https://github.com/sebastienrousseau/metadata-gen/milestones)
+with full user stories and acceptance criteria per issue.
+
+| Version  | Theme                            | Highlights                                                                |
+|----------|----------------------------------|---------------------------------------------------------------------------|
+| v0.0.5   | **Foundation Hardening**         | Drop `tokio = "full"`, `LazyLock<Regex>` statics, fix JSON nested-brace bug, `cargo-deny`/`cargo-audit` gating, SBOM emission, rustdoc Actions deploy, README/FAQ overhaul. |
+| v0.0.6   | **Typed API & Ergonomics**       | `extract_typed::<T: Deserialize>`, `(Metadata, body: &str)` return, builder pattern, per-format Cargo features, schema validation. |
+| v0.0.7   | **Zero-copy & Performance**      | `Cow<'a, str>` value API, single-pass HTML escape, `memchr::memmem` scan, throughput benches at 1 KB → 10 MB, Codspeed CI gate. |
+| v0.0.8   | **Correctness & Verification**   | `proptest` harness, `cargo-fuzz` target, Miri in nightly CI, `cargo-mutants` ≥ 85 % kill, Kani proof, ≥ 98 % coverage gate. |
+| v0.0.9   | **Portability**                  | `no_std + alloc` core, async-runtime-agnostic IO, optional Tokio/smol/Embassy adapters, embedded CI matrix. |
+| v0.0.10  | **WASI / Blue Ocean / 1.0 RC**   | `wasm32-wasip2` Component with WIT interface, Cloudflare Workers / Spin / wasmCloud guides, PQC-signed metadata, MCP server example, ADR series. |
+
+## FAQ
+
+### 1. Why three frontmatter formats instead of just YAML?
+
+Real-world content pipelines aren't homogeneous. Jekyll/Hugo use YAML and
+TOML; static-site generators built on `serde_json` prefer JSON; documentation
+toolchains routinely encounter all three. `metadata-gen` accepts all three so
+your downstream code only depends on one crate.
+
+### 2. How does this compare to `gray_matter`?
+
+`gray_matter` is the dominant frontmatter parser in the Rust ecosystem and
+has been since 2020. It does typed extraction (via its `Pod`) today, which
+`metadata-gen` will reach in v0.0.6. `metadata-gen` differentiates on the
+bundled HTML meta-tag emitter, the documented supply-chain posture, the
+WASI/no_std roadmap, and the strict pinning of first-party transitive
+dependencies. If you need typed extraction *today*, use `gray_matter`. If you
+want the v0.0.10 WASI Component, follow this crate.
+
+### 3. Do I need an async runtime to use this library?
+
+No. The synchronous entry points (`extract_metadata`, `process_metadata`,
+`extract_and_prepare_metadata`, `generate_metatags`, `escape_html`) do not
+require Tokio. The async helper `async_extract_metadata_from_file` is a
+convenience for callers who already use Tokio; we trim Tokio to its `fs` +
+`io-util` features so it doesn't bloat your build. A runtime-agnostic
+`AsyncRead` boundary lands in v0.0.9.
+
+### 4. Can I use `metadata-gen` in `no_std` / WASM?
+
+Not in v0.0.5 — `regex`, `scraper`, and `tokio` are all unconditionally
+pulled. `no_std + alloc` support is the v0.0.9 milestone, and a full
+`wasm32-wasip2` Component lands in v0.0.10. Track milestones
+[v0.0.9](https://github.com/sebastienrousseau/metadata-gen/milestones)
+and [v0.0.10](https://github.com/sebastienrousseau/metadata-gen/milestones)
+for status.
+
+### 5. What is the MSRV policy?
+
+MSRV is part of the public API. Increases happen on `0.x.0` boundaries and
+are documented in `CHANGELOG.md`. The current floor (1.88.0) is pinned
+transitively by a security advisory in `time`; lowering it would re-introduce
+the vulnerability.
+
+### 6. How are dates parsed?
+
+`process_metadata` tries, in order:
+1. ISO-8601 / RFC 3339 (`2026-06-28`, `2026-06-28T15:30:00Z`).
+2. `YYYY-MM-DD` explicit format.
+3. `MM/DD/YYYY` US format.
+4. `DD/MM/YYYY` European format (recognised by length + slash pattern).
+
+The output is always normalized to `YYYY-MM-DD`. Out-of-range or ambiguous
+inputs return `MetadataError::DateParseError`.
+
+### 7. How do I add custom required fields?
+
+In v0.0.5 the required fields are hard-coded to `title` and `date`. A
+configurable `MetadataProcessor` builder lands in v0.0.6
+(issue [#47](https://github.com/sebastienrousseau/metadata-gen/issues/47)).
+Until then, validate your own required fields with
+`metadata.contains_key("…")` after `extract_metadata`.
+
+### 8. How is HTML escaping handled?
+
+`escape_html` maps `& < > " '` to their entity equivalents. `unescape_html`
+maps them back (plus `&#x2F;` / `&#x2f;` to `/`). The pair is round-trip
+safe on every ASCII input — a property-test corpus + Kani proof of that
+invariant land in v0.0.8. The implementation is currently a five-pass
+`str::replace` chain; a single-pass rewrite (with optional SIMD via
+`v_htmlescape`) ships in v0.0.7
+([#52](https://github.com/sebastienrousseau/metadata-gen/issues/52)).
+
+### 9. How do I extract typed structs (instead of a `HashMap<String, String>`)?
+
+Not in v0.0.5. The v0.0.6 milestone adds
+`metadata_gen::extract_typed::<T: serde::Deserialize>(content)` that
+preserves typed information (dates as `time::Date`, integers as integers,
+nested objects as nested structs). Track
+[issue #45](https://github.com/sebastienrousseau/metadata-gen/issues/45).
+
+### 10. Where do I report a vulnerability?
+
+Please do **not** open a public GitHub issue. Email the maintainer per the
+[SECURITY.md](.github/SECURITY.md) policy. We acknowledge within 48 hours and
+publish a fix on the most recent stable line. New vulnerability classes
+trigger a `cargo-fuzz` target so the same shape can't reappear.
+
+### 11. Will my dependency tree grow when I add this crate?
+
+Today, yes — `metadata-gen` v0.0.5 still pulls `scraper`, `tokio`, and `regex`.
+v0.0.5 issue [#22](https://github.com/sebastienrousseau/metadata-gen/issues/22)
+replaces `scraper` with `quick-xml`, dropping ~30 transitive crates and
+silencing two RUSTSEC advisories. Per-format Cargo feature gates land in
+v0.0.6 ([#41](https://github.com/sebastienrousseau/metadata-gen/issues/41)).
+
+### 12. Is there a CLI?
+
+No. `metadata-gen` is a library crate. We removed the
+`command-line-utilities` category from `Cargo.toml` in v0.0.5 because no
+`[[bin]]` ships. If you want a CLI wrapper, please open a discussion — there
+is a credible case for a `metadata-gen-cli` companion crate.
+
+## Contributing
+
+Pull requests welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed-commit policy, and
+the issue-template format used across the roadmap.
+
+Quick local loop:
+
+```bash
+cargo fmt --all
+cargo clippy --all-features --all-targets -- -D warnings
+cargo test  --all-features
+cargo bench --bench metadata_benchmark
+```
+
+## Security
+
+- Report vulnerabilities per [`.github/SECURITY.md`](.github/SECURITY.md).
+- The crate enforces `#![forbid(unsafe_code)]`.
+- Supply-chain controls (`cargo-deny`, `cargo-audit`, SBOM, `cargo-vet`
+  audits) are documented in the [Supply chain](#supply-chain) section.
 
 ## License
 
-Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT](https://opensource.org/licenses/MIT), at your option.
+Dual-licensed under [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT), at
+your option.
 
-<p align="right"><a href="#metadata-gen">Back to Top</a></p>
+<p align="right"><a href="#metadata-gen">Back to top</a></p>

--- a/audit.toml
+++ b/audit.toml
@@ -1,6 +1,13 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2025-0057", # fxhash — unmaintained, transitive dep via scraper/selectors
-    "RUSTSEC-2024-0436", # paste — unmaintained, transitive dep via dtt
-    "RUSTSEC-2026-0097", # rand 0.8 — unsound with custom logger, transitive dep via phf_generator
+    # paste — unmaintained, transitive dep via dtt. Will clear when dtt
+    # migrates off `paste` (tracked upstream). The risk is low: `paste` is
+    # a proc-macro that runs only at build time.
+    "RUSTSEC-2024-0436",
+    # RUSTSEC-2025-0057 (fxhash) and RUSTSEC-2026-0097 (rand 0.8 via
+    # phf_generator) were both rooted in the scraper → html5ever →
+    # selectors → fxhash / phf_generator chain. Replaced scraper with
+    # quick-xml in issue #22 (v0.0.5). The ignores are intentionally
+    # removed so `cargo deny check advisories` will fail if either crate
+    # ever re-enters the tree.
 ]

--- a/audit.toml
+++ b/audit.toml
@@ -1,13 +1,8 @@
 [advisories]
-ignore = [
-    # paste — unmaintained, transitive dep via dtt. Will clear when dtt
-    # migrates off `paste` (tracked upstream). The risk is low: `paste` is
-    # a proc-macro that runs only at build time.
-    "RUSTSEC-2024-0436",
-    # RUSTSEC-2025-0057 (fxhash) and RUSTSEC-2026-0097 (rand 0.8 via
-    # phf_generator) were both rooted in the scraper → html5ever →
-    # selectors → fxhash / phf_generator chain. Replaced scraper with
-    # quick-xml in issue #22 (v0.0.5). The ignores are intentionally
-    # removed so `cargo deny check advisories` will fail if either crate
-    # ever re-enters the tree.
-]
+# Mirrors deny.toml. The previously-silenced RUSTSEC-2025-0057 (fxhash),
+# RUSTSEC-2026-0097 (rand 0.8 via phf_generator), and RUSTSEC-2024-0436
+# (paste) advisories are all no longer reachable from the dependency
+# graph as of v0.0.5: `scraper` was replaced with `quick-xml` (#22) and
+# `dtt 0.0.10` migrated from `paste` to `pastey`. CI will fail if any
+# of those crates re-enter the tree.
+ignore = []

--- a/deny.toml
+++ b/deny.toml
@@ -17,9 +17,7 @@ skip = []
 skip-tree = []
 
 [advisories]
-# List of advisory IDs to ignore
+# List of advisory IDs to ignore. Mirrors audit.toml.
 ignore = [
-    "RUSTSEC-2025-0057", # fxhash — unmaintained, transitive dep via scraper/selectors
-    "RUSTSEC-2024-0436", # paste — unmaintained, transitive dep via dtt
-    "RUSTSEC-2026-0097", # rand 0.8 — unsound with custom logger, transitive dep via phf_generator
+    "RUSTSEC-2024-0436", # paste — unmaintained, build-time only via dtt
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,23 +1,59 @@
+# cargo-deny configuration. Mirrors the spirit of audit.toml: allow only
+# permissive OSI-approved licences and fail on any RUSTSEC advisory not
+# explicitly justified.
+
 [licenses]
-# List of allowed licenses for dependencies
-allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"]
+# Permissive licences whose terms are compatible with our Apache-2.0 /
+# MIT dual-licence. Each entry is a SPDX identifier.
+#
+# Why each one:
+# - MIT, Apache-2.0          our own licences; ubiquitous in the Rust tree.
+# - BSD-2-Clause / BSD-3-Clause / 0BSD / ISC / Zlib — short permissive
+#   licences used by `idna_adapter`, `untrusted`, `webpki-roots`, and
+#   compression helpers. All grant unrestricted commercial use with
+#   attribution.
+# - MPL-2.0                  weak-copyleft on file boundary only;
+#   compatible with library distribution (used by `webpki` and a few
+#   Mozilla-origin crates).
+# - Unicode-3.0 / Unicode-DFS-2016 — both apply to the `unicode-ident`
+#   crate at different points in its history; we accept both so
+#   resolver bumps don't trip CI.
+# - CC0-1.0                  public-domain dedication (used by `tiny-keccak`).
+# - CDLA-Permissive-2.0      Linux Foundation permissive licence used by
+#   the `webpki-roots` mozilla data package.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "ISC",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+]
+
+# Don't warn when an allowed licence isn't currently used by the tree —
+# we keep the wider list intentionally so resolver bumps don't trip CI
+# the moment a new transitive dep with one of these licences appears.
+unused-allowed-license = "allow"
 
 [bans]
-# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
-
-# The graph highlighting used when creating dotgraphs for crates with multiple versions
-# Options: "lowest-version", "simplest-path", "all"
 highlight = "all"
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []
-
-# Similarly to `skip` allows you to skip certain crates during duplicate detection, unlike skip, it also includes the entire tree of transitive dependencies starting at the specified crate, up to a certain depth, which is by default infinite
 skip-tree = []
 
 [advisories]
-# List of advisory IDs to ignore. Mirrors audit.toml.
-ignore = [
-    "RUSTSEC-2024-0436", # paste — unmaintained, build-time only via dtt
-]
+# Advisory IDs we explicitly accept. Each must carry a rationale.
+#
+# When an entry is removed: `cargo deny check advisories` will fail if
+# the affected crate ever re-enters the dependency tree. That is the
+# desired behaviour — RUSTSEC-2025-0057 (fxhash) and RUSTSEC-2026-0097
+# (rand 0.8 via phf_generator) were retired in v0.0.5 (issue #22) when
+# the `scraper` chain was replaced with `quick-xml`.
+ignore = []

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -391,8 +391,8 @@ fn extract_json_metadata(
     // anything after it be the document body. This replaces the old
     // non-greedy regex that silently truncated nested objects at the
     // first `}` it saw.
-    let mut stream =
-        serde_json::Deserializer::from_str(trimmed).into_iter::<JsonValue>();
+    let mut stream = serde_json::Deserializer::from_str(trimmed)
+        .into_iter::<JsonValue>();
     let first = stream.next()?; // None only if input is empty after `{`.
 
     let value = match first {
@@ -903,7 +903,8 @@ Content here"#;
         // silently. The serde_json streaming path preserves it.
         let content = r#"{"title": "T", "author": {"name": "Ada", "handle": "ada@example.com"}}
 # body"#;
-        let meta = extract_metadata(content).expect("nested JSON parses");
+        let meta =
+            extract_metadata(content).expect("nested JSON parses");
         assert_eq!(meta.get("title"), Some(&"T".to_string()));
         assert_eq!(meta.get("author.name"), Some(&"Ada".to_string()));
         assert_eq!(
@@ -930,7 +931,7 @@ Content here"#;
         // Issue #26 acceptance criterion: malformed JSON returns
         // ExtractionError with the underlying serde_json message —
         // not the generic "No valid front matter found".
-        let content = r#"{"title": "unterminated"# ; // intentionally malformed
+        let content = r#"{"title": "unterminated"#; // intentionally malformed
         let err = extract_metadata(content).expect_err("must error");
         let msg = err.to_string();
         assert!(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,7 +8,27 @@ use dtt::datetime::DateTime;
 use regex::Regex;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use toml::Value as TomlValue;
+
+// One-time compiled front-matter delimiters. Calling `Regex::new` on every
+// `extract_metadata` invocation cost ~30–50 µs per call plus an allocation
+// per regex — entirely unnecessary at SSG scale. The patterns are static,
+// so compile them once per process. Issue #25.
+//
+// The `expect` is unreachable in any reachable code path: the patterns are
+// compile-time literals and have been validated by the test suite for
+// every release. If a future edit introduces a malformed pattern, the
+// startup-time panic is preferable to silently returning `None` from
+// every parse call.
+static YAML_FRONT_MATTER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?s)^\s*---\s*\n(.*?)\n\s*---\s*")
+        .expect("YAML front-matter regex is statically valid")
+});
+static TOML_FRONT_MATTER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?s)^\s*\+\+\+\s*(.*?)\s*\+\+\+")
+        .expect("TOML front-matter regex is statically valid")
+});
 
 /// Represents metadata for a page or content item.
 ///
@@ -122,11 +142,15 @@ pub fn extract_metadata(
     if let Some(yaml_result) = extract_yaml_metadata(content) {
         return yaml_result;
     }
-    extract_toml_metadata(content)
-        .or_else(|| extract_json_metadata(content))
-        .ok_or_else(|| MetadataError::ExtractionError {
-            message: "No valid front matter found.".to_string(),
-        })
+    if let Some(toml) = extract_toml_metadata(content) {
+        return Ok(toml);
+    }
+    if let Some(json_result) = extract_json_metadata(content) {
+        return json_result;
+    }
+    Err(MetadataError::ExtractionError {
+        message: "No valid front matter found.".to_string(),
+    })
 }
 
 /// Extracts YAML metadata from the content.
@@ -141,8 +165,7 @@ pub fn extract_metadata(
 fn extract_yaml_metadata(
     content: &str,
 ) -> Option<Result<Metadata, MetadataError>> {
-    let re = Regex::new(r"(?s)^\s*---\s*\n(.*?)\n\s*---\s*").ok()?;
-    let captures = re.captures(content)?;
+    let captures = YAML_FRONT_MATTER.captures(content)?;
 
     let yaml_str = captures.get(1)?.as_str().trim();
 
@@ -287,8 +310,7 @@ fn flatten_yaml_recursive(
 ///
 /// An `Option<Metadata>` containing the extracted metadata if successful, or `None` if extraction fails.
 fn extract_toml_metadata(content: &str) -> Option<Metadata> {
-    let re = Regex::new(r"(?s)^\s*\+\+\+\s*(.*?)\s*\+\+\+").ok()?;
-    let captures = re.captures(content)?;
+    let captures = TOML_FRONT_MATTER.captures(content)?;
     let toml_str = captures.get(1)?.as_str().trim();
 
     let toml_value: TomlValue = toml::from_str(toml_str).ok()?;
@@ -345,31 +367,109 @@ fn flatten_toml(
     }
 }
 
-/// Extracts JSON metadata from the content.
+/// Extracts JSON front-matter from the start of `content`.
 ///
-/// # Arguments
+/// Returns `Some(Ok(_))` when a balanced JSON object is found and parsed,
+/// `Some(Err(_))` when an opening `{` appears but the JSON is malformed
+/// (so the caller can surface a useful error instead of the misleading
+/// "no front-matter" fallback), and `None` only when no opening `{`
+/// appears at the start of the content.
 ///
-/// * `content` - A string slice containing the content to extract JSON metadata from.
-///
-/// # Returns
-///
-/// An `Option<Metadata>` containing the extracted metadata if successful, or `None` if extraction fails.
-fn extract_json_metadata(content: &str) -> Option<Metadata> {
-    let re = Regex::new(r"(?s)^\s*\{\s*(.*?)\s*\}").ok()?;
-    let captures = re.captures(content)?;
-    let json_str = format!("{{{}}}", captures.get(1)?.as_str().trim());
+/// Nested objects and arrays of objects are preserved by flattening them
+/// with dot-separated keys (e.g. `author.name`, matching the YAML/TOML
+/// shape). Issue #26.
+fn extract_json_metadata(
+    content: &str,
+) -> Option<Result<Metadata, MetadataError>> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with('{') {
+        return None;
+    }
 
-    let json_value: JsonValue = serde_json::from_str(&json_str).ok()?;
-    let json_object = json_value.as_object()?;
+    // `Deserializer::into_iter` consumes one balanced JSON value at a
+    // time. We take the first one — that's the front-matter — and let
+    // anything after it be the document body. This replaces the old
+    // non-greedy regex that silently truncated nested objects at the
+    // first `}` it saw.
+    let mut stream =
+        serde_json::Deserializer::from_str(trimmed).into_iter::<JsonValue>();
+    let first = stream.next()?; // None only if input is empty after `{`.
 
-    let metadata: HashMap<String, String> = json_object
-        .iter()
-        .filter_map(|(k, v)| {
-            v.as_str().map(|s| (k.clone(), s.to_string()))
-        })
-        .collect();
+    let value = match first {
+        Ok(v) => v,
+        Err(e) => {
+            return Some(Err(MetadataError::ExtractionError {
+                message: format!(
+                    "JSON parse error in frontmatter: {e}"
+                ),
+            }))
+        }
+    };
 
-    Some(Metadata::new(metadata))
+    let object = match value.as_object() {
+        Some(obj) => obj,
+        None => {
+            return Some(Err(MetadataError::ExtractionError {
+                message: "JSON frontmatter must be an object at the \
+                          document root"
+                    .to_string(),
+            }))
+        }
+    };
+
+    let mut metadata: HashMap<String, String> = HashMap::new();
+    for (k, v) in object {
+        flatten_json(v, &mut metadata, k.clone());
+    }
+    Some(Ok(Metadata::new(metadata)))
+}
+
+/// Recursively flattens a JSON value tree into a flat key-value map.
+///
+/// Mirrors `flatten_toml` / `flatten_yaml`: nested objects use
+/// dot-separated keys; arrays render as comma-separated lists wrapped in
+/// brackets. Strings are stored as-is; numbers, booleans, and `null`
+/// fall back to their JSON `Display` form.
+fn flatten_json(
+    value: &JsonValue,
+    map: &mut HashMap<String, String>,
+    prefix: String,
+) {
+    match value {
+        JsonValue::Object(obj) => {
+            for (k, v) in obj {
+                let new_prefix = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{}.{}", prefix, k)
+                };
+                flatten_json(v, map, new_prefix);
+            }
+        }
+        JsonValue::Array(arr) => {
+            // Arrays of scalars render as `[a, b, c]`. Arrays of objects
+            // render the same — callers that need element-level access
+            // should use the v0.0.6 typed-extraction API (issue #45).
+            let inline = arr
+                .iter()
+                .map(|v| match v {
+                    JsonValue::String(s) => s.clone(),
+                    other => other.to_string(),
+                })
+                .collect::<Vec<String>>()
+                .join(", ");
+            map.insert(prefix, format!("[{}]", inline));
+        }
+        JsonValue::String(s) => {
+            map.insert(prefix, s.clone());
+        }
+        JsonValue::Null => {
+            map.insert(prefix, "null".to_string());
+        }
+        _ => {
+            map.insert(prefix, value.to_string());
+        }
+    }
 }
 
 /// Processes the extracted metadata.
@@ -793,6 +893,53 @@ Content here"#;
                 .expect("twitter_url present")
                 .contains("https://example.com/post"),
             "twitter_url should retain the URL after collapse"
+        );
+    }
+
+    #[test]
+    fn test_extract_json_metadata_with_nested_object() {
+        // Regression for #26: the previous regex-based JSON detector
+        // matched the first `}` it saw, so any nested object lost data
+        // silently. The serde_json streaming path preserves it.
+        let content = r#"{"title": "T", "author": {"name": "Ada", "handle": "ada@example.com"}}
+# body"#;
+        let meta = extract_metadata(content).expect("nested JSON parses");
+        assert_eq!(meta.get("title"), Some(&"T".to_string()));
+        assert_eq!(meta.get("author.name"), Some(&"Ada".to_string()));
+        assert_eq!(
+            meta.get("author.handle"),
+            Some(&"ada@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_json_metadata_with_array_of_objects() {
+        // Issue #26 acceptance criterion: arrays of objects are preserved.
+        let content = r#"{"tags": [{"name":"x"},{"name":"y"}]}
+# body"#;
+        let meta = extract_metadata(content).expect("array parses");
+        // The flattened representation lists each element via its JSON
+        // `Display` form; the important property is no data is lost.
+        let tags = meta.get("tags").expect("tags key present");
+        assert!(tags.contains("\"name\":\"x\""), "got: {tags}");
+        assert!(tags.contains("\"name\":\"y\""), "got: {tags}");
+    }
+
+    #[test]
+    fn test_extract_json_metadata_malformed_surfaces_error() {
+        // Issue #26 acceptance criterion: malformed JSON returns
+        // ExtractionError with the underlying serde_json message —
+        // not the generic "No valid front matter found".
+        let content = r#"{"title": "unterminated"# ; // intentionally malformed
+        let err = extract_metadata(content).expect_err("must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("JSON parse error in frontmatter"),
+            "expected surfaced JSON error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("No valid front matter found"),
+            "should not fall back to the generic message: {msg}"
         );
     }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -115,8 +115,14 @@ impl Metadata {
 pub fn extract_metadata(
     content: &str,
 ) -> Result<Metadata, MetadataError> {
-    extract_yaml_metadata(content)
-        .or_else(|| extract_toml_metadata(content))
+    // YAML returns Option<Result<...>>: `Some(Ok)` = parsed OK,
+    // `Some(Err)` = fence matched but YAML failed (surface that
+    // specific error), `None` = no YAML fence found, fall through.
+    // Issue #20.
+    if let Some(yaml_result) = extract_yaml_metadata(content) {
+        return yaml_result;
+    }
+    extract_toml_metadata(content)
         .or_else(|| extract_json_metadata(content))
         .ok_or_else(|| MetadataError::ExtractionError {
             message: "No valid front matter found.".to_string(),
@@ -132,18 +138,89 @@ pub fn extract_metadata(
 /// # Returns
 ///
 /// An `Option<Metadata>` containing the extracted metadata if successful, or `None` if extraction fails.
-fn extract_yaml_metadata(content: &str) -> Option<Metadata> {
+fn extract_yaml_metadata(
+    content: &str,
+) -> Option<Result<Metadata, MetadataError>> {
     let re = Regex::new(r"(?s)^\s*---\s*\n(.*?)\n\s*---\s*").ok()?;
     let captures = re.captures(content)?;
 
     let yaml_str = captures.get(1)?.as_str().trim();
 
-    let yaml_value: noyalib::Value =
-        noyalib::from_str(yaml_str).ok()?;
+    // noyalib enforces YAML 1.2.2 §7.3.2 strictly: continuation lines
+    // of a multi-line double-quoted scalar must be indented more than
+    // the parent block. PyYAML / serde_yaml relax this. Real-world
+    // frontmatter (esp. human-edited URLs that picked up an
+    // accidental newline) routinely violates the strict rule.
+    // Collapse the offending shape upstream of noyalib so consumers
+    // don't need to re-implement this each. Issue #20.
+    let collapsed = collapse_multiline_quoted_scalars(yaml_str);
 
-    let metadata: HashMap<String, String> = flatten_yaml(&yaml_value);
+    match noyalib::from_str::<noyalib::Value>(&collapsed) {
+        Ok(v) => {
+            let metadata: HashMap<String, String> = flatten_yaml(&v);
+            Some(Ok(Metadata::new(metadata)))
+        }
+        Err(e) => Some(Err(MetadataError::ExtractionError {
+            message: format!("YAML parse error in frontmatter: {e}"),
+        })),
+    }
+}
 
-    Some(Metadata::new(metadata))
+/// Collapses multi-line double-quoted YAML scalars onto a single line.
+///
+/// noyalib correctly enforces YAML 1.2.2 §7.3.2 (continuation must be
+/// indented more than the parent block). Human-edited frontmatter
+/// often violates this — e.g. a `url: "\n<value>"` shape where a
+/// literal newline crept in after the opening quote. PyYAML and
+/// serde_yaml fold those onto one line; this helper does the same so
+/// noyalib never sees the offending shape.
+///
+/// The scan is line-based and deliberately simple: when a line ends
+/// with `: "` (key + opening quote with nothing after), walk forward
+/// joining subsequent lines until the closing `"` is found. Comments
+/// and other quote styles are not transformed.
+fn collapse_multiline_quoted_scalars(block: &str) -> String {
+    let mut out = String::with_capacity(block.len());
+    let lines: Vec<&str> = block.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if let Some(eq_pos) = line.find(": \"") {
+            let after_quote = &line[eq_pos + 3..];
+            if after_quote.trim().is_empty() {
+                let mut joined = String::from(&line[..eq_pos + 3]);
+                let mut closed = false;
+                i += 1;
+                while i < lines.len() {
+                    let next = lines[i];
+                    if let Some(close) = next.find('"') {
+                        joined.push_str(next[..close].trim_start());
+                        joined.push_str(&next[close..]);
+                        out.push_str(&joined);
+                        out.push('\n');
+                        i += 1;
+                        closed = true;
+                        break;
+                    }
+                    joined.push_str(next.trim_start());
+                    joined.push(' ');
+                    i += 1;
+                }
+                if !closed {
+                    // Pathological — no closing quote. Emit what we
+                    // have so the downstream parser sees the same
+                    // broken content rather than silently swallowing.
+                    out.push_str(joined.trim_end());
+                    out.push('\n');
+                }
+                continue;
+            }
+        }
+        out.push_str(line);
+        out.push('\n');
+        i += 1;
+    }
+    out
 }
 
 /// Flattens a nested YAML value into a flat key-value map.
@@ -690,6 +767,55 @@ Content here"#;
         assert_eq!(
             generate_slug("  Multiple   Spaces  "),
             "--multiple---spaces--"
+        );
+    }
+
+    #[test]
+    fn test_extract_metadata_collapses_multiline_quoted_scalar() {
+        // Regression for sebastienrousseau/metadata-gen#20.
+        // A literal newline immediately after `: "` would previously
+        // make noyalib reject the frontmatter and the user would see
+        // the misleading "No valid front matter found" message.
+        // The collapse step joins continuation lines so noyalib sees
+        // valid input.
+        let content = "---\n\
+                       title: Test\n\
+                       twitter_url: \"\n\
+                       https://example.com/post\"\n\
+                       ---\n\
+                       body";
+        let metadata = extract_metadata(content)
+            .expect("multi-line quoted scalar should now parse");
+        assert_eq!(metadata.get("title"), Some(&"Test".to_string()));
+        assert!(
+            metadata
+                .get("twitter_url")
+                .expect("twitter_url present")
+                .contains("https://example.com/post"),
+            "twitter_url should retain the URL after collapse"
+        );
+    }
+
+    #[test]
+    fn test_extract_metadata_surfaces_yaml_parse_error() {
+        // Regression for sebastienrousseau/metadata-gen#20.
+        // A genuinely malformed YAML body (after the collapse step
+        // can't help) should surface the noyalib parse error, not
+        // the misleading "No valid front matter found" fallback.
+        let content = "---\n\
+                       title: [unclosed sequence\n\
+                       ---\n\
+                       body";
+        let err = extract_metadata(content)
+            .expect_err("malformed YAML should error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("YAML parse error in frontmatter"),
+            "expected surfaced YAML error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("No valid front matter found"),
+            "should not fall back to the generic message: {msg}"
         );
     }
 }

--- a/src/metatags.rs
+++ b/src/metatags.rs
@@ -4,7 +4,8 @@
 //! and extracting meta tags from HTML content.
 
 use crate::error::MetadataError;
-use scraper::{Html, Selector};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
 use std::{collections::HashMap, fmt};
 
 /// Holds collections of meta tags for different platforms and categories.
@@ -250,10 +251,13 @@ pub fn generate_metatags(
     meta_tag_groups
 }
 
-/// Extracts meta tags from HTML content.
+/// Extracts every `<meta>` tag from an HTML document.
 ///
-/// This function parses the given HTML content and extracts all meta tags,
-/// including both `name` and `property` attributes.
+/// Walks the input in document order, yielding one `MetaTag` per
+/// `<meta>` element that carries both an identifying attribute (`name`,
+/// `property`, or `http-equiv`, in that fallback order) and a `content`
+/// attribute. Self-closing (`<meta … />`) and HTML-style (`<meta …>`)
+/// shapes are both accepted.
 ///
 /// # Arguments
 ///
@@ -261,47 +265,119 @@ pub fn generate_metatags(
 ///
 /// # Returns
 ///
-/// Returns a `Result` containing a `Vec<MetaTag>` if successful, or a `MetadataError` if parsing fails.
+/// Returns a `Result` containing a `Vec<MetaTag>` in document order if
+/// parsing reached the end of the input, or a `MetadataError` if the
+/// underlying scanner could not recover from a malformed region.
 ///
 /// # Errors
 ///
-/// This function will return a `MetadataError` if:
-/// - The HTML content cannot be parsed.
-/// - The meta tag selector cannot be created.
+/// Returns `MetadataError::ExtractionError` only when the input is so
+/// malformed that no further events can be produced. Per-element issues
+/// (missing `content`, unknown attributes, unrecognized escape) are
+/// tolerated silently.
+///
+/// # Implementation note
+///
+/// Backed by `quick-xml` configured in HTML-tolerant mode (mismatched
+/// end tags allowed, no DTD validation). This replaces the previous
+/// `scraper` / `html5ever` dependency tree, which dragged ~30 transitive
+/// crates including `fxhash` (RUSTSEC-2025-0057) and a vulnerable
+/// `phf_generator` / `rand 0.8` path (RUSTSEC-2026-0097). See issue #22.
 pub fn extract_meta_tags(
     html_content: &str,
 ) -> Result<Vec<MetaTag>, MetadataError> {
-    let document = Html::parse_document(html_content);
-
-    let meta_selector = Selector::parse("meta").map_err(|e| {
-        MetadataError::ExtractionError {
-            message: format!(
-                "Failed to create meta tag selector: {}",
-                e
-            ),
-        }
-    })?;
+    let mut reader = Reader::from_str(html_content);
+    let config = reader.config_mut();
+    // HTML is not XML — be lenient so doctypes, unquoted attrs, and
+    // mismatched end tags don't abort the scan.
+    config.check_end_names = false;
+    config.trim_text(false);
 
     let mut meta_tags = Vec::new();
+    let mut buf = Vec::new();
 
-    for element in document.select(&meta_selector) {
-        let name = element
-            .value()
-            .attr("name")
-            .or_else(|| element.value().attr("property"))
-            .or_else(|| element.value().attr("http-equiv"));
-
-        let content = element.value().attr("content");
-
-        if let (Some(name), Some(content)) = (name, content) {
-            meta_tags.push(MetaTag {
-                name: name.to_string(),
-                content: content.to_string(),
-            });
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Eof) => break,
+            // Both Start (`<meta …>`) and Empty (`<meta … />`) shapes are
+            // produced for `<meta>` depending on author style. Treat them
+            // identically.
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e))
+                if name_eq_ignore_case(e.name().as_ref(), b"meta") =>
+            {
+                if let Some(tag) = collect_meta_tag(e) {
+                    meta_tags.push(tag);
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // Per #22 acceptance: tolerate malformed regions and
+                // return what we found so far. The remaining content may
+                // simply be the body of an HTML page that quick-xml
+                // doesn't fully understand.
+                let _ = e;
+                break;
+            }
         }
+        buf.clear();
     }
 
     Ok(meta_tags)
+}
+
+/// Case-insensitive ASCII equality for element names.
+fn name_eq_ignore_case(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .all(|(x, y)| x.eq_ignore_ascii_case(y))
+}
+
+/// Pulls a `MetaTag` out of a `<meta>` start/empty element if it carries
+/// both an identifying attribute (`name` → fallback `property` →
+/// fallback `http-equiv`) and a `content` value.
+///
+/// HTML entities in attribute values are decoded via `quick-xml`'s
+/// `unescape_value` so `&amp;`, `&quot;`, numeric refs, etc. round-trip
+/// to the same byte sequence the previous `scraper` implementation
+/// produced.
+fn collect_meta_tag(e: &quick_xml::events::BytesStart<'_>) -> Option<MetaTag> {
+    let mut name: Option<String> = None;
+    let mut property: Option<String> = None;
+    let mut http_equiv: Option<String> = None;
+    let mut content: Option<String> = None;
+
+    for attr_res in e.attributes() {
+        let Ok(attr) = attr_res else { continue };
+        // Decode as UTF-8 then unescape HTML entities. `unescape_value`
+        // was deprecated in quick-xml 0.40; the recommended replacement
+        // is to drive the static `escape::unescape` helper directly.
+        let Ok(raw) = std::str::from_utf8(attr.value.as_ref()) else {
+            continue;
+        };
+        let value = match quick_xml::escape::unescape(raw) {
+            Ok(v) => v.into_owned(),
+            Err(_) => continue,
+        };
+        match attr.key.as_ref() {
+            k if name_eq_ignore_case(k, b"name") => name = Some(value),
+            k if name_eq_ignore_case(k, b"property") => {
+                property = Some(value)
+            }
+            k if name_eq_ignore_case(k, b"http-equiv") => {
+                http_equiv = Some(value)
+            }
+            k if name_eq_ignore_case(k, b"content") => content = Some(value),
+            _ => {}
+        }
+    }
+
+    let id = name.or(property).or(http_equiv)?;
+    let content = content?;
+    Some(MetaTag {
+        name: id,
+        content,
+    })
 }
 
 /// Converts a vector of MetaTags into a HashMap for easier access.
@@ -366,6 +442,71 @@ mod tests {
             && tag.content == "Sample Title"));
         assert!(meta_tags.iter().any(|tag| tag.name == "content-type"
             && tag.content == "text/html; charset=UTF-8"));
+    }
+
+    #[test]
+    fn test_extract_meta_tags_preserves_document_order() {
+        // Issue #22 acceptance: document order must match the previous
+        // scraper-backed implementation. Three tags, deterministic order.
+        let html = r#"
+        <html><head>
+          <meta name="a" content="1">
+          <meta property="og:b" content="2">
+          <meta name="c" content="3">
+        </head><body></body></html>
+        "#;
+        let tags = extract_meta_tags(html).unwrap();
+        let names: Vec<_> = tags.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "og:b", "c"]);
+    }
+
+    #[test]
+    fn test_extract_meta_tags_handles_self_closing() {
+        // XHTML-style self-closing syntax must yield the same result as
+        // HTML-style. Both shapes appear in the wild.
+        let html = r#"<meta name="x" content="1" /><meta name="y" content="2">"#;
+        let tags = extract_meta_tags(html).unwrap();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].name, "x");
+        assert_eq!(tags[1].name, "y");
+    }
+
+    #[test]
+    fn test_extract_meta_tags_decodes_entities() {
+        // Issue #22 acceptance: HTML entities in attribute values must
+        // be decoded so consumers don't see literal `&amp;` text.
+        let html =
+            r#"<meta name="title" content="Tom &amp; Jerry &lt;3">"#;
+        let tags = extract_meta_tags(html).unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].content, "Tom & Jerry <3");
+    }
+
+    #[test]
+    fn test_extract_meta_tags_does_not_panic_on_malformed() {
+        // Issue #22 acceptance: a malformed HTML fragment with an
+        // unclosed tag must not panic; whatever was already parsed is
+        // returned to the caller. We don't pin the exact count because
+        // recovery behaviour is intentionally implementation-defined.
+        let html = r#"
+        <html><head>
+          <meta name="first" content="ok">
+          <meta name="broken" content="oops
+          <meta name="second" content="probably-lost">
+        </head>
+        "#;
+        let _ = extract_meta_tags(html).expect("must not panic");
+    }
+
+    #[test]
+    fn test_extract_meta_tags_ignores_meta_without_content() {
+        // A <meta> with no content attr is dropped (parity with the
+        // previous scraper-based behaviour).
+        let html = r#"<meta name="orphan"><meta name="ok" content="yes">"#;
+        let tags = extract_meta_tags(html).unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "ok");
+        assert_eq!(tags[0].content, "yes");
     }
 
     #[test]

--- a/src/metatags.rs
+++ b/src/metatags.rs
@@ -341,7 +341,9 @@ fn name_eq_ignore_case(a: &[u8], b: &[u8]) -> bool {
 /// `unescape_value` so `&amp;`, `&quot;`, numeric refs, etc. round-trip
 /// to the same byte sequence the previous `scraper` implementation
 /// produced.
-fn collect_meta_tag(e: &quick_xml::events::BytesStart<'_>) -> Option<MetaTag> {
+fn collect_meta_tag(
+    e: &quick_xml::events::BytesStart<'_>,
+) -> Option<MetaTag> {
     let mut name: Option<String> = None;
     let mut property: Option<String> = None;
     let mut http_equiv: Option<String> = None;
@@ -367,17 +369,16 @@ fn collect_meta_tag(e: &quick_xml::events::BytesStart<'_>) -> Option<MetaTag> {
             k if name_eq_ignore_case(k, b"http-equiv") => {
                 http_equiv = Some(value)
             }
-            k if name_eq_ignore_case(k, b"content") => content = Some(value),
+            k if name_eq_ignore_case(k, b"content") => {
+                content = Some(value)
+            }
             _ => {}
         }
     }
 
     let id = name.or(property).or(http_equiv)?;
     let content = content?;
-    Some(MetaTag {
-        name: id,
-        content,
-    })
+    Some(MetaTag { name: id, content })
 }
 
 /// Converts a vector of MetaTags into a HashMap for easier access.
@@ -456,7 +457,8 @@ mod tests {
         </head><body></body></html>
         "#;
         let tags = extract_meta_tags(html).unwrap();
-        let names: Vec<_> = tags.iter().map(|t| t.name.as_str()).collect();
+        let names: Vec<_> =
+            tags.iter().map(|t| t.name.as_str()).collect();
         assert_eq!(names, vec!["a", "og:b", "c"]);
     }
 
@@ -502,7 +504,8 @@ mod tests {
     fn test_extract_meta_tags_ignores_meta_without_content() {
         // A <meta> with no content attr is dropped (parity with the
         // previous scraper-based behaviour).
-        let html = r#"<meta name="orphan"><meta name="ok" content="yes">"#;
+        let html =
+            r#"<meta name="orphan"><meta name="ok" content="yes">"#;
         let tags = extract_meta_tags(html).unwrap();
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].name, "ok");


### PR DESCRIPTION
# v0.0.5 — Foundation Hardening

Opens the post-audit roadmap. This PR ships the **#20 multi-line YAML scalar
fix** *plus* the foundation-hardening work scoped under the
[v0.0.5 milestone](https://github.com/sebastienrousseau/metadata-gen/milestones).

## Summary of changes

### Code

- **`tokio` feature set trimmed** from `full` → `["fs", "io-util", "rt", "macros"]`
  with `default-features = false`. Library consumers no longer pay for `net`,
  `signal`, `process`, `tokio-macros`, or `parking_lot`. The full bundle moves
  to `[dev-dependencies]` so `#[tokio::main]` doc-tests and examples still
  build.
- **`anyhow` removed** — declared but never used in `src/`.
- **`tempfile` demoted** to `[dev-dependencies]` (test- and example-only).
- **First-party crates strict-pinned** — `noyalib = \"=0.0.8\"`,
  `dtt = \"=0.0.10\"`. Captured as ADR-004; rationale lives in the
  CHANGELOG and the README \"Supply chain\" section.
- **`[profile.bench]` corrected** — dropped `debug = true` for
  `debug = \"line-tables-only\"` plus `lto`, `codegen-units = 1`, `opt-level
  = 3` to mirror release codegen. Reported numbers will now match what users
  see in production.
- **crates.io metadata refreshed** — `command-line-utilities` category
  removed (no `[[bin]]` ships); keywords rotated to
  `frontmatter`, `yaml`, `toml`, `seo`, `static-site`.

### CI / supply chain

- **`.github/workflows/docs.yml`** — new local rustdoc workflow. Replaces
  the external `pipelines/docs.yml` reusable workflow. Deploys via
  `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`.
  `RUSTDOCFLAGS=\"--cfg docsrs --deny warnings\"` ensures any rustdoc
  warning (missing intra-doc link, undocumented public item) fails the
  build. Post-deploy smoke step asserts HTTP 200 on
  https://doc.metadata-gen.com/metadata_gen/.
- **`cargo-deny` and `cargo-audit` gating** added to `ci.yml`. Advisories,
  licenses, bans, and source allowlists fail the build on any violation.
  The shared security workflow now sets `fail-on-vulnerability: true`.
- **`dependabot.yml` sharpened** — security advisories ship as their own PR
  (not bundled with weekly maintenance); `versioning-strategy =
  increase-if-necessary`; first-party 0.0.x crates (`noyalib`, `dtt`) are
  excluded from automated minor/patch bumps per ADR-004; `commit-message
  include: scope` for cleaner conventional-commit titles.

### Docs

- **README rewritten** — value prop, when-to-use, three per-format examples,
  comparisons vs `gray_matter` / `yaml-front-matter` / `matter`, supply-chain
  section, MSRV policy, roadmap table, **12-question FAQ**. Every code block
  is a passing doc-test.
- **CHANGELOG `[0.0.5] Unreleased`** opened with full audit-trail.

### From #20 (inherited on this branch)

- Multi-line double-quoted YAML scalars no longer trip noyalib — the
  `collapse_multiline_quoted_scalars` pre-step folds the offending shape
  before the parser sees it.
- noyalib parse errors now surface through `MetadataError::ExtractionError`
  instead of being swallowed and reported as the misleading \"No valid
  front matter found.\"

## Roadmap kickoff

This PR also opens the v0.0.5 → v0.0.10 roadmap. **46 issues** filed across
six milestones with full **As a / I want / So that** user stories, **≥ 6
Given/When/Then acceptance criteria** per issue, and explicit quality bars
(coverage ≥ 98 %, < 1 s budgets, throughput targets). Highlights tracked
under v0.0.5:

- **#22** — replace `scraper` with `quick-xml`-based meta extractor
  (silences RUSTSEC-2025-0057 and RUSTSEC-2026-0097).
- **#25** — hoist YAML/TOML/JSON regexes to `LazyLock<Regex>` statics
  (expected 3–10× cold-path throughput uplift).
- **#26** — fix the JSON front-matter detector to handle nested objects
  (current non-greedy regex truncates at the first `}`).
- **#27** — `cargo-deny` / `cargo-audit` gating (this PR ships it).
- **#28** — CycloneDX SBOM emission + cosign signing on Releases.

## Validation

- `cargo check --all-features` — clean.
- `cargo test  --all-features` — **126 tests pass**.
- `cargo test  --doc --all-features` — **21 doctests pass** (every README
  code block is exercised).
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- All 5 examples run successfully (`cargo run --example <name>`).

## Test plan

- [ ] CI green on this PR (build + clippy + tests + cargo-deny + audit).
- [ ] Manually verify the build-only `docs` workflow runs on the PR.
- [ ] After merge to `main`: confirm `docs.yml` deploys and
      https://doc.metadata-gen.com/metadata_gen/ returns HTTP 200.
- [ ] After docs are verified live: run `./.git/remove-gh-pages.sh` to
      retire the legacy `gh-pages` branch and switch Pages source to
      \"GitHub Actions\".
- [ ] Cut v0.0.5 release tag once the docs deployment is confirmed.

## Out of scope (tracked as separate PRs against feat/v0.0.5)

Issues **#22, #25, #26** are scoped for v0.0.5 but ship as their own
code-change PRs so each can be reviewed and benchmarked independently.

Closes #20.