### PR TITLE
fix(ci): enable cross-platform matrix + pin reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,24 @@ concurrency:
 
 jobs:
   ci:
-    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@main
+    # Pinned to a SHA (immutable) rather than @main (mutable). Bump
+    # deliberately when upstream rust-ci.yml changes are worth absorbing.
+    uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@3b0c5ce38f72e1b765265a172ac7407daad7f244 # tracks main 2026-06-28
     with:
       rust-version: 'stable'
       run-coverage: true
+      # Local cargo-audit + cargo-deny jobs supersede the reusable audit.
       run-audit: false
-      coverage-exclude: 'crates/*'
+      # Validate the README's "Linux, macOS, Windows" claim. Matrix is
+      # macos-latest + windows-latest; needs the linux check to pass.
+      run-cross-platform: true
+      # `coverage-exclude: 'crates/*'` removed — no `crates/` directory
+      # exists in the repo since the v0.0.3 noyalib migration.
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   security:
-    uses: sebastienrousseau/pipelines/.github/workflows/security.yml@main
+    uses: sebastienrousseau/pipelines/.github/workflows/security.yml@3b0c5ce38f72e1b765265a172ac7407daad7f244 # tracks main 2026-06-28
     with:
       language: rust
       fail-on-vulnerability: true


### PR DESCRIPTION
## Summary

Three issues with the CI config visible on the post-v0.0.5 main run:

1. **`Test (${{ matrix.os }})` was silently SKIPPED.** The reusable
   `rust-ci.yml` gates the matrix behind `if: inputs.run-cross-platform`
   and we never passed it. The README's *Tested on Linux, macOS, and
   Windows* claim was unsubstantiated.
2. **`coverage-exclude: 'crates/*'` is dead config** — no such directory
   exists in the repo since the v0.0.3 noyalib migration.
3. **Reusable workflows referenced as `@main` (mutable).** Pinned to
   `3b0c5ce38f72e1b765265a172ac7407daad7f244` with a tracking comment.

## Test plan

- [ ] CI green on this PR.
- [ ] `Test (macos-latest)` and `Test (windows-latest)` both appear in
      the check list and pass.
- [ ] cargo-deny, cargo-audit, Check & Test, Coverage, CodeQL all stay
      green.
- [ ] After merge: verify the next main CI run shows the matrix jobs
      executing (not skipped).