### PR TITLE
chore(release): v0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "metadata-gen"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -48,12 +48,12 @@ path = "src/lib.rs"
 # - `tokio` is intentionally feature-trimmed to `fs` + `io-util` for the
 #   single `async_extract_metadata_from_file` helper. We do not need `net`,
 #   `signal`, `process`, or `parking_lot`. See ADR-008 in v0.0.6.
-dtt = "=0.0.10"
-quick-xml = "0.40"
+dtt = "=0.0.11"
+quick-xml = "0.41"
 regex = "1.12"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
-noyalib = { version = "=0.0.8", default-features = false, features = ["std"] }
+noyalib = { version = "=0.0.15", default-features = false, features = ["std"] }
 thiserror = "2.0"
 time = { version = "0.3", features = ["parsing"] }
 tokio = { version = "1.50", default-features = false, features = ["fs", "io-util", "rt", "macros"] }

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-metadata-gen = "0.0.5"
+metadata-gen = "0.0.6"
 ```
 
 Minimum Supported Rust Version: **1.88.0** — see the


### PR DESCRIPTION
- sync first-party deps to latest published
- minimal RUSTSEC remediation (crossbeam-epoch/anyhow/ammonia/quick-xml)
- bump version to 0.0.6 + README/CHANGELOG

Assisted-by: Claude:claude-opus-4-7

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
