### PR TITLE
ci(docs): key the Pages concurrency group by ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,12 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  # Keyed by ref: the Pages deployment must still serialise on `main`,
+  # but a pull request must not share a queue with it. A shared group
+  # let unrelated runs cancel a pull request's `Build rustdoc`, and a
+  # cancelled run never satisfies a required status check — so the
+  # pull request could not be merged.
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
`Build rustdoc` is a **required** status check. `docs.yml` put every run — `main` and pull requests alike — into a single concurrency group:

```yaml
concurrency:
  group: pages
  cancel-in-progress: false
```

With one shared group, an unrelated run can cancel a pull request's `Build rustdoc`. A cancelled run never reports success, so the pull request becomes unmergeable **with nothing visibly failing** — the check simply sits there as "expected".

Seen on #80, whose Docs run was cancelled on 10 August and never re-ran. Every other check on it was green; the merge was refused for a check that had no way to complete.

## Fix

```yaml
group: pages-${{ github.ref }}
```

This keeps the serialisation that actually matters — one Pages deployment at a time on `main` — without letting unrelated branches contend with each other. `cancel-in-progress: false` is unchanged.